### PR TITLE
Refactors Deprecated Magic Image Helper

### DIFF
--- a/app/views/spree/admin/orders/_stock_item.html.erb
+++ b/app/views/spree/admin/orders/_stock_item.html.erb
@@ -1,6 +1,6 @@
 <% shipment.manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
-    <td class="item-image"><%= mini_image(item.variant) %></td>
+    <td class="item-image"><%= item.variant.display_image.mini_url %></td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.part && item.line_item %>


### PR DESCRIPTION
The magical method_missing/define_method image-helpers of yore are deprecated.
