### PR TITLE
Variants Allowed To Be Parts.

### DIFF
--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -3,6 +3,7 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
 
   def index
     @parts = product.assemblies_parts.includes(:assembly, :part)
+    @parts = product.variants.flat_map(&:parts_variants) if @parts.empty?
   end
 
   def remove

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -12,10 +12,11 @@
   <tbody>
     <% @available_products.each do |part| %>
       <tr id="<%= dom_id(part) %>"
+        data-hook="admin_parts_available_sku_table"
         class="<%= "with-variants" if part.has_variants? %>">
 
         <td><%= part.name %></td>
-        <td data-hook="admin_parts_sku_select">
+        <td>
           <% if part.has_variants? %>
             <%- opts = part.variants.map {|v| [v.sku, v.id] } %>
             <%= select_tag "part[id]",


### PR DESCRIPTION
Sometimes there could be parts that are assigned to variants. This allows the index to return parts that are a part of variants or parts that are apart of products (master variants). Included is a cleanup of the parts availability listing table to be able to be completely overwritten, versus just one td tag.